### PR TITLE
Fix Chinese locale default parameter

### DIFF
--- a/Locales/zhCN.lua
+++ b/Locales/zhCN.lua
@@ -1,4 +1,4 @@
-﻿local L = LibStub("AceLocale-3.0"):NewLocale("EnchantCheck", "zhCN", true)
+﻿local L = LibStub("AceLocale-3.0"):NewLocale("EnchantCheck", "zhCN")
 if not L then return end
 
 L["Version"] = true

--- a/Locales/zhTW.lua
+++ b/Locales/zhTW.lua
@@ -1,4 +1,4 @@
-﻿local L = LibStub("AceLocale-3.0"):NewLocale("EnchantCheck", "zhTW", true)
+﻿local L = LibStub("AceLocale-3.0"):NewLocale("EnchantCheck", "zhTW")
 if not L then return end
 
 L["Version"] = true


### PR DESCRIPTION
## Summary
- Remove the `true` parameter from zhCN and zhTW locale definitions
- Only the primary locale (enUS) should be marked as default
- Follows AceLocale-3.0 best practices and fixes locale loading

## Technical Details
This resolves the same issue as PR #26 but without merge conflicts by applying the changes to the current main branch.

The third parameter in `AceLocale-3.0:NewLocale()` indicates whether the locale is the default/fallback locale. Chinese variants should not be marked as default - only English should have this flag.

## Files Changed
- `Locales/zhCN.lua` - Remove `true` parameter
- `Locales/zhTW.lua` - Remove `true` parameter