### PR TITLE
Rescan on SOCKET_INFO_SUCCESS for live gem updates

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -199,6 +199,7 @@ end
 function EnchantCheck:OnEnable()
 	self:RegisterEvent("INSPECT_READY");
 	self:RegisterEvent("PLAYER_EQUIPMENT_CHANGED");
+	self:RegisterEvent("SOCKET_INFO_SUCCESS");
 	self:RegisterEvent("PLAYER_ENTERING_WORLD");
 	self:RegisterEvent("PLAYER_LOGIN");
 
@@ -211,6 +212,7 @@ end
 function EnchantCheck:OnDisable()
 	self:UnregisterEvent("INSPECT_READY");
 	self:UnregisterEvent("PLAYER_EQUIPMENT_CHANGED");
+	self:UnregisterEvent("SOCKET_INFO_SUCCESS");
 	self:UnregisterEvent("PLAYER_ENTERING_WORLD");
 	self:UnregisterEvent("PLAYER_LOGIN");
 
@@ -888,6 +890,15 @@ end
 -- the newly-equipped item. UNIT_INVENTORY_CHANGED fires too early and would
 -- scan stale slot data.
 function EnchantCheck:PLAYER_EQUIPMENT_CHANGED(event, equipSlot, hasCurrent)
+	self:CheckGear("player")
+end
+
+----------------------------------------------
+-- SOCKET_INFO_SUCCESS()
+----------------------------------------------
+-- PLAYER_EQUIPMENT_CHANGED does not fire when a gem is socketed into an
+-- already-equipped item, so the missing-gem overlay needs its own trigger.
+function EnchantCheck:SOCKET_INFO_SUCCESS(event)
 	self:CheckGear("player")
 end
 


### PR DESCRIPTION
## Summary

- Register `SOCKET_INFO_SUCCESS` and trigger `CheckGear("player")`. Socketing a gem into an equipped item updates the link but does not fire `PLAYER_EQUIPMENT_CHANGED`, so the missing-gem overlay stayed lit until something else triggered a scan (equip swap, pane reopen, `/ec check`).
- The generation token in `CheckGear` already handles rapid-fire safely; `ContinueOnItemLoad` covers any momentary delay in the updated link being readable.

## Test plan

- [x] Equip an item with an empty socket → "Missing gems" TR overlay shows.
- [x] Open Blizzard's socketing UI, insert and apply a gem → TR icon disappears without closing the character pane.
- [x] Cancel the socket UI without applying → no scan triggered, overlay unchanged.