### PR TITLE
Delay socket rescan so the equipped link has time to update

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -898,8 +898,17 @@ end
 ----------------------------------------------
 -- PLAYER_EQUIPMENT_CHANGED does not fire when a gem is socketed into an
 -- already-equipped item, so the missing-gem overlay needs its own trigger.
+-- The event fires before WoW finishes updating the equipped item's link, so
+-- a small delay lets the slot/cache settle before we re-parse. The gen
+-- token in CheckGear absorbs any duplicates.
 function EnchantCheck:SOCKET_INFO_SUCCESS(event)
-	self:CheckGear("player")
+	if self.socketRescanTimer then
+		self:CancelTimer(self.socketRescanTimer)
+	end
+	self.socketRescanTimer = self:ScheduleTimer(function()
+		self.socketRescanTimer = nil
+		self:CheckGear("player")
+	end, 0.5)
 end
 
 ----------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #33. The `SOCKET_INFO_SUCCESS` rescan fired before `GetInventoryItemLink` reflected the newly-applied gem, so the scan re-read the stale link and the missing-gem overlay stayed lit until something else triggered another scan. Defer the rescan by 0.5s via `ScheduleTimer` so the slot has time to settle; cancel any in-flight timer if another success fires first. The gen token in `CheckGear` absorbs any duplicate triggers.

## Test plan

- [x] Socket a gem into an equipped item with the character pane open — TR icon clears within ~0.5s without closing the pane.