### PR TITLE
Flag gear that's wrong for your class/spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ pyvenv.cfg
 bin
 
 .claude/
+
+# Git worktrees
+.worktrees/
+
+# Local design docs / implementation plans (never committed)
+docs/superpowers/

--- a/EnchantCheck.toc
+++ b/EnchantCheck.toc
@@ -21,3 +21,4 @@ Libs\AceTimer-3.0\AceTimer-3.0.xml
 constants.lua
 Locales\locales.xml
 main.lua
+speccheck.lua

--- a/EnchantCheck_Mainline.toc
+++ b/EnchantCheck_Mainline.toc
@@ -21,3 +21,4 @@ Libs\AceTimer-3.0\AceTimer-3.0.xml
 constants.lua
 Locales\locales.xml
 main.lua
+speccheck.lua

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -25,6 +25,7 @@ L["TOOLTIP_MISSING_ENCHANT"] = "Missing enchant"
 L["TOOLTIP_MISSING_GEM"] = "Missing gem"
 L["TOOLTIP_LOW_ILVL"] = "Low item level"
 L["TOOLTIP_PURCHASEABLE_UPGRADE"] = "Can add socket"
+L["TOOLTIP_HEADER"] = "Issues with this item (Enchant Check):"
 
 L["WRONG_ARMOR_TYPE"] = "Wrong armor type:"
 L["WRONG_STATS"] = "Wrong stats for spec:"

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -26,6 +26,11 @@ L["TOOLTIP_MISSING_GEM"] = "Missing gem"
 L["TOOLTIP_LOW_ILVL"] = "Low item level"
 L["TOOLTIP_PURCHASEABLE_UPGRADE"] = "Can add socket"
 
+L["WRONG_ARMOR_TYPE"] = "Wrong armor type:"
+L["WRONG_STATS"] = "Wrong stats for spec:"
+L["WRONG_ARMOR_TYPE_DETAIL"] = "%s (your class wears %s)"      -- have, want
+L["WRONG_STAT_DETAIL"] = "grants %s, your spec uses %s"        -- have, want
+
 L["INVSLOT_"..INVSLOT_HEAD] = "Head"
 L["INVSLOT_"..INVSLOT_NECK] = "Neck"
 L["INVSLOT_"..INVSLOT_SHOULDER] = "Shoulder"

--- a/constants.lua
+++ b/constants.lua
@@ -138,6 +138,8 @@ EnchantCheckConstants.DEFAULTS = {
 		warnMissingGems = true,
 		warnLowItemLevel = true,
 		warnPurchaseableUpgrades = true,
+		warnWrongArmorType = true,
+		warnWrongStats = true,
 
 		-- Sound Settings
 		enableSounds = false,
@@ -245,5 +247,66 @@ EnchantCheckConstants.EQUIPMENT_SLOTS = {
 	ONE_HANDED_COUNT = 16, -- Total slots when using 1H+offhand
 	EXCLUDED_FROM_ILVL = { 4, 19 }, -- BODY and TABARD slots excluded from item level calculations
 }
+
+----------------------------------------------
+-- Item Classification IDs
+-- (mirrors Enum.ItemClass / Enum.ItemArmorSubclass; literals avoid load-order
+-- dependence on the Enum table, consistent with the numeric SLOT_IDS approach)
+----------------------------------------------
+EnchantCheckConstants.ITEM_CLASS = {
+	WEAPON = 2,
+	ARMOR = 4,
+}
+
+-- GetItemStats() table keys for each primary stat. The same identifiers are
+-- global localized strings (e.g. _G["ITEM_MOD_STRENGTH_SHORT"] == "Strength"),
+-- which we reuse as locale-correct tooltip search keywords.
+EnchantCheckConstants.PRIMARY_STAT_KEYS = {
+	[1] = "ITEM_MOD_STRENGTH_SHORT",
+	[2] = "ITEM_MOD_AGILITY_SHORT",
+	[4] = "ITEM_MOD_INTELLECT_SHORT",
+}
+
+-- Class token -> preferred armor subclass.
+EnchantCheckConstants.CLASS_ARMOR_TYPE = {
+	MAGE = 1, PRIEST = 1, WARLOCK = 1,                 -- Cloth
+	ROGUE = 2, DRUID = 2, MONK = 2, DEMONHUNTER = 2,   -- Leather
+	HUNTER = 3, SHAMAN = 3, EVOKER = 3,                -- Mail
+	WARRIOR = 4, PALADIN = 4, DEATHKNIGHT = 4,         -- Plate
+}
+
+-- Class token -> primary stat, for classes whose primary does NOT vary by spec.
+EnchantCheckConstants.CLASS_PRIMARY_STAT = {
+	WARRIOR = 1, PALADIN = 1, DEATHKNIGHT = 1,                  -- Strength
+	HUNTER = 2, ROGUE = 2, DEMONHUNTER = 2,                     -- Agility (DH Devourer overridden below)
+	MAGE = 4, PRIEST = 4, WARLOCK = 4, EVOKER = 4,              -- Intellect
+}
+
+-- Spec ID -> primary stat, for specs whose primary differs from their class's
+-- other specs (hybrid classes Druid/Monk/Shaman, plus the Demon Hunter Devourer
+-- spec). Takes precedence over CLASS_PRIMARY_STAT, so a class can keep its default
+-- in CLASS_PRIMARY_STAT and list only its divergent spec(s) here.
+-- Spec IDs verified against warcraft.wiki.gg/wiki/SpecializationID.
+EnchantCheckConstants.SPEC_PRIMARY_STAT = {
+	-- Druid
+	[102] = 4, -- Balance      (Intellect)
+	[103] = 2, -- Feral        (Agility)
+	[104] = 2, -- Guardian     (Agility)
+	[105] = 4, -- Restoration  (Intellect)
+	-- Monk
+	[268] = 2, -- Brewmaster   (Agility)
+	[269] = 2, -- Windwalker   (Agility)
+	[270] = 4, -- Mistweaver   (Intellect)
+	-- Shaman
+	[262] = 4, -- Elemental    (Intellect)
+	[263] = 2, -- Enhancement  (Agility)
+	[264] = 4, -- Restoration  (Intellect)
+	-- Demon Hunter (Havoc/Vengeance default to Agility via CLASS_PRIMARY_STAT)
+	[1480] = 4, -- Devourer     (Intellect, added in patch 12.0 Midnight)
+}
+
+-- Equipment slots that carry a class-relevant armor type. Excludes cloak (slot
+-- 15, always Cloth), neck/rings/trinkets (no armor type), shirt and tabard.
+EnchantCheckConstants.ARMOR_TYPE_SLOTS = { 1, 3, 5, 6, 7, 8, 9, 10 }
 
 -- Constants are already globally available from line 7

--- a/main.lua
+++ b/main.lua
@@ -1033,6 +1033,7 @@ end
 function EnchantCheck:PLAYER_LOGIN(event)
 	-- Create overlays and hook character frame for auto-check
 	self:CreateAllOverlays("Character")
+	self:RegisterTooltipHook()
 	if PaperDollFrame then
 		self:HookScript(PaperDollFrame, "OnShow", "OnCharacterFrameShow")
 	end

--- a/main.lua
+++ b/main.lua
@@ -691,12 +691,48 @@ function EnchantCheck:CreateAllOverlays(prefix)
 end
 
 function EnchantCheck:ClearAllOverlays(prefix)
+	if self.slotIssueLines then self.slotIssueLines[prefix] = nil end
 	if not self.slotOverlays or not self.slotOverlays[prefix] then return end
 
 	for _, overlay in pairs(self.slotOverlays[prefix]) do
 		overlay:Hide()
 		for _, icon in pairs(overlay.icons) do
 			icon:Hide()
+		end
+	end
+end
+
+function EnchantCheck:BuildSlotIssueLines(prefix, results)
+	self.slotIssueLines = self.slotIssueLines or {}
+	local lines = {}
+	self.slotIssueLines[prefix] = lines
+
+	local SEV = EnchantCheckConstants.UI.SEVERITY
+	local function add(slot, text, severity)
+		lines[slot] = lines[slot] or {}
+		table.insert(lines[slot], { text = text, severity = severity })
+	end
+
+	if self:GetSetting("warnLowItemLevel") then
+		for _, d in ipairs(results.lowLevelItems) do add(d.slot, L["TOOLTIP_LOW_ILVL"], SEV.ERROR) end
+	end
+	if self:GetSetting("warnMissingEnchants") then
+		for _, slot in ipairs(results.missingEnchants) do add(slot, L["TOOLTIP_MISSING_ENCHANT"], SEV.ERROR) end
+	end
+	if self:GetSetting("warnMissingGems") then
+		for _, slot in ipairs(results.missingGems) do add(slot, L["TOOLTIP_MISSING_GEM"], SEV.ERROR) end
+	end
+	if self:GetSetting("warnPurchaseableUpgrades") then
+		for _, d in ipairs(results.upgradeableItems) do add(d.slot, L["TOOLTIP_PURCHASEABLE_UPGRADE"], SEV.WARNING) end
+	end
+	if self:GetSetting("warnWrongArmorType") then
+		for _, d in ipairs(results.wrongArmorType) do
+			add(d.slot, L["WRONG_ARMOR_TYPE"] .. " " .. d.reason, SEV.ERROR)
+		end
+	end
+	if self:GetSetting("warnWrongStats") then
+		for _, d in ipairs(results.wrongStats) do
+			add(d.slot, L["WRONG_STATS"] .. " " .. d.reason, SEV.ERROR)
 		end
 	end
 end
@@ -746,6 +782,20 @@ function EnchantCheck:UpdateSlotOverlays(prefix, results)
 		for _, itemData in ipairs(results.upgradeableItems) do
 			if not slotIssues[itemData.slot] then slotIssues[itemData.slot] = {} end
 			slotIssues[itemData.slot].purchaseableUpgrade = true
+		end
+	end
+
+	-- Wrong armor type / wrong stats (error severity; red border, no corner icon)
+	if #results.wrongArmorType > 0 and self:GetSetting("warnWrongArmorType") then
+		for _, data in ipairs(results.wrongArmorType) do
+			if not slotIssues[data.slot] then slotIssues[data.slot] = {} end
+			slotIssues[data.slot].hasError = true
+		end
+	end
+	if #results.wrongStats > 0 and self:GetSetting("warnWrongStats") then
+		for _, data in ipairs(results.wrongStats) do
+			if not slotIssues[data.slot] then slotIssues[data.slot] = {} end
+			slotIssues[data.slot].hasError = true
 		end
 	end
 
@@ -824,6 +874,7 @@ function EnchantCheck:CheckGear(unit, printWarnings)
 			wrongStats = self:CheckWrongStats(unit, items),
 		}
 
+		self:BuildSlotIssueLines(framePrefix, results)
 		self:UpdateSlotOverlays(framePrefix, results)
 
 		if printWarnings then

--- a/main.lua
+++ b/main.lua
@@ -346,6 +346,10 @@ function EnchantCheck:ProcessItemData(unit, item, slot)
 
 	item.stats = C_Item.GetItemStats(item.link) or {}
 
+	local _, _, _, _, _, classID, subclassID = C_Item.GetItemInfoInstant(item.link)
+	item.classID = classID
+	item.subclassID = subclassID
+
 	item.sockets = 0
 	for label in pairs(item.stats) do
 		if label:find("EMPTY_SOCKET_", 1, true) then
@@ -549,6 +553,24 @@ function EnchantCheck:BuildChatWarnings(unit, results)
 		end
 		table.insert(warnings, self:FormatMessage(L["MISSING_ENCHANTS"] .. " " .. table.concat(parts, ", "), EnchantCheckConstants.UI.SEVERITY.WARNING))
 		hasAnyIssues = true
+	end
+
+	-- Wrong armor type
+	if #results.wrongArmorType > 0 and self:GetSetting("warnWrongArmorType") then
+		for _, data in ipairs(results.wrongArmorType) do
+			local msg = L["WRONG_ARMOR_TYPE"] .. " " .. L["INVSLOT_"..data.slot] .. " — " .. data.reason
+			table.insert(warnings, self:FormatMessage(msg, EnchantCheckConstants.UI.SEVERITY.ERROR))
+			hasAnyIssues = true
+		end
+	end
+
+	-- Wrong stats for spec
+	if #results.wrongStats > 0 and self:GetSetting("warnWrongStats") then
+		for _, data in ipairs(results.wrongStats) do
+			local msg = L["WRONG_STATS"] .. " " .. L["INVSLOT_"..data.slot] .. " — " .. data.reason
+			table.insert(warnings, self:FormatMessage(msg, EnchantCheckConstants.UI.SEVERITY.ERROR))
+			hasAnyIssues = true
+		end
 	end
 
 	if not hasAnyIssues then
@@ -798,6 +820,8 @@ function EnchantCheck:CheckGear(unit, printWarnings)
 			missingEnchants = self:CheckMissingEnchants(items),
 			missingGems = self:CheckMissingGems(items),
 			upgradeableItems = self:CheckPurchaseableUpgrades(items),
+			wrongArmorType = self:CheckWrongArmorType(unit, items),
+			wrongStats = self:CheckWrongStats(unit, items),
 		}
 
 		self:UpdateSlotOverlays(framePrefix, results)

--- a/main.lua
+++ b/main.lua
@@ -111,6 +111,8 @@ function EnchantCheck:ShowConfig()
 	self:Printf("  Smart Notifications: |cffFFFF00%s|cffFFFFFF", tostring(self:GetSetting("smartNotifications") or "nil"))
 	self:Printf("  Ignore Heirlooms: |cffFFFF00%s|cffFFFFFF", tostring(self:GetSetting("ignoreHeirlooms") or "nil"))
 	self:Printf("  Enable Sounds: |cffFFFF00%s|cffFFFFFF", tostring(self:GetSetting("enableSounds") or "nil"))
+	self:Printf("  Warn Wrong Armor Type: |cffFFFF00%s|cffFFFFFF", tostring(self:GetSetting("warnWrongArmorType")))
+	self:Printf("  Warn Wrong Stats: |cffFFFF00%s|cffFFFFFF", tostring(self:GetSetting("warnWrongStats")))
 end
 
 function EnchantCheck:SetConfigValue(setting, value)

--- a/speccheck.lua
+++ b/speccheck.lua
@@ -195,9 +195,10 @@ function EnchantCheck:OnItemTooltip(tooltip)
 	if not entries then return end
 
 	tooltip:AddLine(" ")
+	tooltip:AddLine(L["TOOLTIP_HEADER"], 1, 1, 1)
 	for _, entry in ipairs(entries) do
 		local rgb = SEVERITY_RGB[entry.severity] or SEVERITY_RGB[C.UI.SEVERITY.ERROR]
-		tooltip:AddLine(entry.text, rgb[1], rgb[2], rgb[3], true)
+		tooltip:AddLine("- " .. entry.text, rgb[1], rgb[2], rgb[3], true)
 	end
 end
 

--- a/speccheck.lua
+++ b/speccheck.lua
@@ -1,0 +1,159 @@
+----------------------------------------------
+-- EnchantCheck — Class/Spec Gear Checks
+-- Detects gear that is wrong for the unit's class/spec: wrong armor type,
+-- and wrong primary stat on weapons and trinkets (base stats + trinket procs).
+----------------------------------------------
+local L = LibStub("AceLocale-3.0"):GetLocale("EnchantCheck")
+local C = EnchantCheckConstants
+
+-- Localized name for a primary stat id (reuses the client's own global string).
+local function PrimaryStatName(stat)
+	local key = C.PRIMARY_STAT_KEYS[stat]
+	return (key and _G[key]) or tostring(stat)
+end
+
+-- Which primary stat, if any, this item's base stat block carries.
+local function BasePrimaryStat(stats)
+	if not stats then return nil end
+	for stat, key in pairs(C.PRIMARY_STAT_KEYS) do
+		if stats[key] and stats[key] > 0 then
+			return stat
+		end
+	end
+	return nil
+end
+
+----------------------------------------------
+-- Unit resolution
+----------------------------------------------
+
+-- Returns the unit's primary stat (1=Str, 2=Agi, 4=Int) or nil if unknown
+-- (e.g. inspect data not yet loaded).
+function EnchantCheck:GetUnitPrimaryStat(unit)
+	local specID
+	if UnitIsUnit(unit, "player") then
+		local idx = GetSpecialization()
+		if idx then
+			specID = GetSpecializationInfo(idx)
+		end
+	else
+		specID = GetInspectSpecialization(unit)
+	end
+	if not specID or specID == 0 then return nil end
+
+	-- Hybrid classes resolved by spec; all others by class.
+	local stat = C.SPEC_PRIMARY_STAT[specID]
+	if stat then return stat end
+
+	local _, _, _, _, _, classFile = GetSpecializationInfoByID(specID)
+	return (classFile and C.CLASS_PRIMARY_STAT[classFile]) or nil
+end
+
+-- Returns the unit's preferred armor subclass (1-4) or nil.
+function EnchantCheck:GetUnitArmorType(unit)
+	local _, classFile = UnitClass(unit)
+	return (classFile and C.CLASS_ARMOR_TYPE[classFile]) or nil
+end
+
+----------------------------------------------
+-- Detection
+----------------------------------------------
+
+-- Armor pieces whose type doesn't match the class. Returns { {slot, reason}, ... }.
+function EnchantCheck:CheckWrongArmorType(unit, items)
+	local out = {}
+	if not self:GetSetting("warnWrongArmorType") then return out end
+
+	local want = self:GetUnitArmorType(unit)
+	if not want then return out end
+
+	for _, slot in ipairs(C.ARMOR_TYPE_SLOTS) do
+		local item = items[slot]
+		if item and item.link and item.classID == C.ITEM_CLASS.ARMOR
+			and item.subclassID and item.subclassID ~= want then
+			local haveName = C_Item.GetItemSubClassInfo(C.ITEM_CLASS.ARMOR, item.subclassID)
+			local wantName = C_Item.GetItemSubClassInfo(C.ITEM_CLASS.ARMOR, want)
+			out[#out + 1] = {
+				slot = slot,
+				reason = string.format(L["WRONG_ARMOR_TYPE_DETAIL"], haveName or "?", wantName or "?"),
+			}
+		end
+	end
+	return out
+end
+
+-- Scans a trinket's tooltip for a primary stat that isn't the spec's. Returns
+-- the wrong stat id when a wrong primary appears and the correct one does not,
+-- else nil. Catches proc/on-use stats that aren't in the base stat block.
+function EnchantCheck:TrinketProcWrongPrimary(unit, slot, primaryStat)
+	if not C_TooltipInfo or not C_TooltipInfo.GetInventoryItem then return nil end
+	local data = C_TooltipInfo.GetInventoryItem(unit, slot)
+	if not data or not data.lines then return nil end
+
+	local correctName = PrimaryStatName(primaryStat)
+	local foundWrong, hasCorrect
+
+	for _, line in ipairs(data.lines) do
+		local text = line.leftText
+		if text then
+			if text:find(correctName, 1, true) then
+				hasCorrect = true
+			end
+			for stat in pairs(C.PRIMARY_STAT_KEYS) do
+				if stat ~= primaryStat and text:find(PrimaryStatName(stat), 1, true) then
+					foundWrong = stat
+				end
+			end
+		end
+	end
+
+	if foundWrong and not hasCorrect then
+		return foundWrong
+	end
+	return nil
+end
+
+-- Weapons and trinkets carrying the wrong primary stat. Returns { {slot, reason}, ... }.
+function EnchantCheck:CheckWrongStats(unit, items)
+	local out = {}
+	if not self:GetSetting("warnWrongStats") then return out end
+
+	local primaryStat = self:GetUnitPrimaryStat(unit)
+	if not primaryStat then return out end
+
+	local SLOT = C.SLOT_IDS
+
+	-- Weapons: base stat block only.
+	for _, slot in ipairs({ SLOT.MAINHAND, SLOT.OFFHAND }) do
+		local item = items[slot]
+		if item and item.link and item.classID == C.ITEM_CLASS.WEAPON then
+			local base = BasePrimaryStat(item.stats)
+			if base and base ~= primaryStat then
+				out[#out + 1] = {
+					slot = slot,
+					reason = string.format(L["WRONG_STAT_DETAIL"], PrimaryStatName(base), PrimaryStatName(primaryStat)),
+				}
+			end
+		end
+	end
+
+	-- Trinkets: base stat block, then proc/on-use tooltip scan.
+	for _, slot in ipairs({ SLOT.TRINKET1, SLOT.TRINKET2 }) do
+		local item = items[slot]
+		if item and item.link then
+			local base = BasePrimaryStat(item.stats)
+			local wrong = (base and base ~= primaryStat) and base or nil
+			if not wrong then
+				wrong = self:TrinketProcWrongPrimary(unit, slot, primaryStat)
+			end
+			if wrong then
+				out[#out + 1] = {
+					slot = slot,
+					reason = string.format(L["WRONG_STAT_DETAIL"], PrimaryStatName(wrong), PrimaryStatName(primaryStat)),
+				}
+			end
+		end
+	end
+
+	return out
+end

--- a/speccheck.lua
+++ b/speccheck.lua
@@ -157,3 +157,58 @@ function EnchantCheck:CheckWrongStats(unit, items)
 
 	return out
 end
+
+----------------------------------------------
+-- Tooltip injection
+----------------------------------------------
+
+-- Tooltip RGB per severity (AddLine needs floats, not the chat color codes).
+local SEVERITY_RGB = {
+	[C.UI.SEVERITY.GOOD]    = { 0, 1, 0 },
+	[C.UI.SEVERITY.INFO]    = { 0, 1, 1 },
+	[C.UI.SEVERITY.WARNING] = { 1, 1, 0 },
+	[C.UI.SEVERITY.ERROR]   = { 1, 0, 0 },
+}
+
+function EnchantCheck:OnItemTooltip(tooltip)
+	if tooltip ~= GameTooltip then return end
+
+	local owner = tooltip:GetOwner()
+	if not owner or not owner.GetName then return end
+	local name = owner:GetName()
+	if not name then return end
+
+	local prefix
+	if name:find("^Character") then
+		prefix = "Character"
+	elseif name:find("^Inspect") then
+		prefix = "Inspect"
+	else
+		return
+	end
+
+	local slotId = owner.GetID and owner:GetID()
+	if not slotId or slotId == 0 then return end
+
+	local byPrefix = self.slotIssueLines and self.slotIssueLines[prefix]
+	local entries = byPrefix and byPrefix[slotId]
+	if not entries then return end
+
+	tooltip:AddLine(" ")
+	for _, entry in ipairs(entries) do
+		local rgb = SEVERITY_RGB[entry.severity] or SEVERITY_RGB[C.UI.SEVERITY.ERROR]
+		tooltip:AddLine(entry.text, rgb[1], rgb[2], rgb[3], true)
+	end
+end
+
+function EnchantCheck:RegisterTooltipHook()
+	if self.tooltipHooked then return end
+	if not (TooltipDataProcessor and TooltipDataProcessor.AddTooltipPostCall
+		and Enum and Enum.TooltipDataType) then
+		return
+	end
+	TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Item, function(tooltip)
+		EnchantCheck:OnItemTooltip(tooltip)
+	end)
+	self.tooltipHooked = true
+end


### PR DESCRIPTION
## Summary

Adds a new check family that flags equipped gear which is wrong for the character's class/spec, alongside the existing missing-enchant/gem/ilvl checks:

- **Wrong armor type** — armor pieces in the 8 armor slots that aren't the class's preferred type (e.g. a Monk wearing Cloth).
- **Wrong primary stat on weapons** — a weapon whose base primary stat doesn't match the active spec (e.g. a caster holding a Strength weapon).
- **Wrong primary stat on trinkets** — base stat block **and** proc/on-use effects. This catches the motivating case: *Withered Saptor's Paw* (base Haste, **Agility** proc) on a Mistweaver Monk, whose primary is Intellect — the wrong stat only appears in the tooltip effect text, so it's found via a tooltip scan.

All three are **error severity**.

## How it surfaces

- **Chat report** (`/ec check`): new `Wrong armor type:` / `Wrong stats for spec:` rows.
- **Paperdoll/Inspect border**: flagged slots get the red error border (no new corner icon).
- **Item tooltip** (new): hovering a Character/Inspect slot appends an `Issues with this item (Enchant Check):` section listing every issue for that item, each row dash-prefixed. Uses `TooltipDataProcessor.AddTooltipPostCall`, scoped to paperdoll slot buttons via `tooltip:GetOwner()`.
- **Settings**: `warnWrongArmorType` and `warnWrongStats` (default on), shown in `/ec config` and toggleable via `/ec set` / `/ec toggle`.

## Implementation notes

- New file `speccheck.lua` (registered in both `.toc` files) holds class/spec resolution and the three detection functions, keeping `main.lua` from growing further.
- Spec→primary-stat is resolved via a `SPEC_PRIMARY_STAT` table (player uses `GetSpecialization`; inspect uses `GetInspectSpecialization`, which has no primary-stat API). Includes the patch 12.0 Demon Hunter **Devourer** spec (Intellect). All spec IDs verified against warcraft.wiki.gg.
- Tooltip text matches the client's own localized stat names (`ITEM_MOD_*_SHORT` globals), so the trinket scan is locale-correct.
- Deliberate: missing-enchant/gem tooltip rows are red (matching their red slot border), while the chat report keeps them yellow.
- Also includes a small `.gitignore` change to ignore `.worktrees/` and local design docs.

## Follow-ups (not in this PR)

- Translations for the new strings in deDE/ruRU/zhCN/zhTW (currently fall through to enUS, per the project's locale convention).

## Test Plan (validated in-game on a Mistweaver Monk)

- [x] `/ec check` flags Withered Saptor's Paw: `Wrong stats for spec: Trinket 2 — grants Agility, your spec uses Intellect`
- [x] Wrong armor type flagged on an armor slot; correct gear not flagged
- [x] Red slot border on flagged paperdoll slots
- [x] Tooltip shows the `Issues with this item (Enchant Check):` section with dash-prefixed rows
- [x] `/ec config` shows the two new settings; `/ec toggle warnWrongStats` suppresses the trinket flag
- [x] Inspect frame applies the checks using the inspected unit's class/spec
- [x] No Lua errors on load or during checks